### PR TITLE
fix: typo of backend url in '2. render projects setup' tutorial

### DIFF
--- a/src/data/post/course-lessons/lesson-2-deploy-persistence.md
+++ b/src/data/post/course-lessons/lesson-2-deploy-persistence.md
@@ -83,7 +83,7 @@ app.use(
 - Specify the root directory (backend)
 - As a buid command we want `npm install` and as run command `npm run start`
 
-Confirm, once done check the url under `api/expense` - the API should be working. Note the url, we'll need it in a minute.
+Confirm, once done check the url under `api/expenses` - the API should be working. Note the url, we'll need it in a minute.
 
 **Frontend**
 


### PR DESCRIPTION
The correction for exercise 1 defined the route '/api/expenses'. The typo of this route was corrected in the render projects setup tutorial.